### PR TITLE
only pick up annotated classes as entities

### DIFF
--- a/src/main/java/org/springframework/data/custom/mapping/CustomMappingContext.java
+++ b/src/main/java/org/springframework/data/custom/mapping/CustomMappingContext.java
@@ -18,6 +18,8 @@ package org.springframework.data.custom.mapping;
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.Field;
 
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.data.custom.annotation.Custom;
 import org.springframework.data.mapping.context.AbstractMappingContext;
 import org.springframework.data.mapping.model.SimpleTypeHolder;
 import org.springframework.data.util.TypeInformation;
@@ -35,6 +37,15 @@ public class CustomMappingContext extends AbstractMappingContext<CustomPersisten
 	@Override
 	protected CustomPersistentProperty createPersistentProperty(final Field field, final PropertyDescriptor descriptor, final CustomPersistentEntityImpl<?> owner, final SimpleTypeHolder simpleTypeHolder) {
 		return new CustomPersistentProperty(field, descriptor, owner, simpleTypeHolder);
+	}
+
+	@Override
+	protected boolean shouldCreatePersistentEntityFor(final TypeInformation<?> type) {
+		return super.shouldCreatePersistentEntityFor(type) && typeHasCustomAnnotation(type);
+	}
+
+	private boolean typeHasCustomAnnotation(final TypeInformation<?> type) {
+		return AnnotationUtils.findAnnotation(type.getType(), Custom.class) != null;
 	}
 
 }

--- a/src/main/java/org/springframework/data/custom/mapping/CustomPersistentProperty.java
+++ b/src/main/java/org/springframework/data/custom/mapping/CustomPersistentProperty.java
@@ -18,6 +18,8 @@ package org.springframework.data.custom.mapping;
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.Field;
 
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.data.custom.annotation.Custom;
 import org.springframework.data.mapping.Association;
 import org.springframework.data.mapping.PersistentEntity;
 import org.springframework.data.mapping.model.AnnotationBasedPersistentProperty;
@@ -32,6 +34,15 @@ public class CustomPersistentProperty extends AnnotationBasedPersistentProperty<
 	@Override
 	protected Association<CustomPersistentProperty> createAssociation() {
 		return new Association<CustomPersistentProperty>(this, null);
+	}
+
+	@Override
+	public boolean isEntity() {
+		return !isTransient() && typeHasCustomAnnotation();
+	}
+
+	private boolean typeHasCustomAnnotation() {
+		return AnnotationUtils.findAnnotation(getType(), Custom.class) != null;
 	}
 
 }

--- a/src/test/java/org/springframework/data/custom/EntityInformationTest.java
+++ b/src/test/java/org/springframework/data/custom/EntityInformationTest.java
@@ -26,9 +26,11 @@ import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 import org.springframework.data.custom.EntityInformationTest.Application;
+import org.springframework.data.custom.mapping.CustomMappingContext;
 import org.springframework.data.custom.repository.config.EnableCustomRepositories;
 import org.springframework.data.custom.test.CustomEntity;
 import org.springframework.data.custom.test.CustomEntityRepository;
+import org.springframework.data.custom.test.CustomNotAnEntity;
 import org.springframework.data.custom.test.JpaEntity;
 import org.springframework.data.custom.test.JpaEntityRepository;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
@@ -52,6 +54,14 @@ public class EntityInformationTest {
 		assertThat(repositories.getEntityInformationFor(JpaEntity.class), is(instanceOf(JpaEntityInformation.class)));
 		assertThat(repositories
 				.getEntityInformationFor(CustomEntity.class), is(instanceOf(ReflectionEntityInformation.class)));
+
+	}
+
+	@Test
+	public void nestedClassesAreNotPickedUpAsEntities() {
+		final CustomMappingContext cmc = _context.getBean(CustomMappingContext.class);
+		assertNotNull(cmc.getPersistentEntity(CustomEntity.class));
+		assertNull(cmc.getPersistentEntity(CustomNotAnEntity.class));
 	}
 
 	@EnableAutoConfiguration

--- a/src/test/java/org/springframework/data/custom/test/CustomEntity.java
+++ b/src/test/java/org/springframework/data/custom/test/CustomEntity.java
@@ -32,4 +32,6 @@ public class CustomEntity {
 	private Integer id;
 
 	private String message;
+
+	private CustomNotAnEntity notAnEntity;
 }

--- a/src/test/java/org/springframework/data/custom/test/CustomEntityRepositoryImpl.java
+++ b/src/test/java/org/springframework/data/custom/test/CustomEntityRepositoryImpl.java
@@ -26,7 +26,7 @@ public class CustomEntityRepositoryImpl implements CustomEntityRepositoryCustom 
 
 	@Override
 	public CustomEntity findOne(final Integer id) {
-		return id != null && id == KNOWN_ID ? new CustomEntity(KNOWN_ID, "foo") : null;
+		return id != null && id == KNOWN_ID ? new CustomEntity(KNOWN_ID, "foo", new CustomNotAnEntity("bar")) : null;
 	}
 
 	@Override

--- a/src/test/java/org/springframework/data/custom/test/CustomNotAnEntity.java
+++ b/src/test/java/org/springframework/data/custom/test/CustomNotAnEntity.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Molindo GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.data.custom.test;
 
 import lombok.AllArgsConstructor;

--- a/src/test/java/org/springframework/data/custom/test/CustomNotAnEntity.java
+++ b/src/test/java/org/springframework/data/custom/test/CustomNotAnEntity.java
@@ -1,0 +1,13 @@
+package org.springframework.data.custom.test;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class CustomNotAnEntity {
+
+	private String message;
+}


### PR DESCRIPTION
The problem is that anything other than simple or transient types get registered as entities by spring-data-rest. This leads to spring-data-rest wrapping a nested non-entity property into its `Resource` wrapper with `content` and `links`. Only letting `@Custom` types be entities solves this.